### PR TITLE
Change dry-struct to dry-initializer for optional attributes

### DIFF
--- a/iban_calculator.gemspec
+++ b/iban_calculator.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-configurable', '~> 0.7'
-  spec.add_dependency 'dry-struct'
+  spec.add_dependency 'dry-initializer'
+  spec.add_dependency 'dry-types'
   spec.add_dependency 'savon', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/lib/iban_calculator/response.rb
+++ b/lib/iban_calculator/response.rb
@@ -1,19 +1,20 @@
-require 'dry-struct'
+require 'dry-initializer'
+require 'dry-types'
 
 module IbanCalculator
-  class Response < Dry::Struct::Value
+  class Response
+    extend Dry::Initializer
+
     CONCLUSIVENESS_THRESHOLD = 32
     CORRECTNESS_THRESHOLD = 127
 
-    constructor_type :schema
-
-    attribute :result, Dry::Types['strict.string']
-    attribute :return_code, Dry::Types['coercible.int']
-    attribute :iban, Dry::Types['strict.string'].optional
-    attribute :country, Dry::Types['strict.string'].optional
-    attribute :bank_code, Dry::Types['strict.string'].optional
-    attribute :bank, Dry::Types['strict.string'].optional
-    attribute :account_number, Dry::Types['strict.string'].optional
+    option :result, Dry::Types['strict.string']
+    option :return_code, Dry::Types['coercible.integer']
+    option :iban, Dry::Types['coercible.string'], optional: true
+    option :country, Dry::Types['coercible.string'], optional: true
+    option :bank_code, Dry::Types['coercible.string'], optional: true
+    option :bank, Dry::Types['coercible.string'], optional: true
+    option :account_number, Dry::Types['coercible.string'], optional: true
 
     def valid?
       return_code < CORRECTNESS_THRESHOLD && result == 'passed'

--- a/lib/iban_calculator/version.rb
+++ b/lib/iban_calculator/version.rb
@@ -1,3 +1,3 @@
 module IbanCalculator
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
After upgrading `dry-struct` to 0.5.0 it was causing problems with our use of `constructor_type`. Swapped it for `dry-initializer` instead.